### PR TITLE
Initial addition of manifest.yml and .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+deploy:
+  edge: true
+  provider: cloudfoundry
+  username: deploy-dotgov
+  password:
+    secure: kTucjJLA26THRTft6G9QK79hZba2UckcWOxoK1gjKZapept3AJmwMAiERXbixTJAxvtI+YP9p2rPDzQ826iFoOKRX9jw4G8Z7AIIOcX8zVQf9WdgULmuMRLSI/LBDaT5Da032MXS4lt/bQkUyCODbtxNJAR1pBingtaUkytwFLQ=
+  api: https://api.18f.gov
+  organization: dotgov
+  space: prod

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: dotgov
+  memory: 64M
+  buildpack: https://github.com/cloudfoundry-incubator/staticfile-buildpack.git
+ domain: pulse.18f.gov
+  env:
+    FORCE_HTTPS: true


### PR DESCRIPTION
Adding an initial `manifest.yml` and `.travis.yml` file, refs #40 and #44. I was not sure what we had decided the url for the project was going to be and left that open to be completed in review of this pull request, see https://github.com/18F/dotgov-dashboard/compare/add-manifest-travis-file?expand=1#diff-8f7df7fa0d4d3156b5cf623a87156eceR6.