### PR TITLE
Production webhook in place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ deploy:
 script:
 - npm install
 - bower install
+
+sudo: required

--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -1,0 +1,43 @@
+import time
+from fabric.api import run, execute, env, cd
+
+"""
+Manage auto-deploy webhooks remotely.
+
+Production hook:
+
+  forever start -l $HOME/pulse/hookshot.log -a deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+  forever restart deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+  forever stop deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+"""
+
+environment = "production"
+branch = "production"
+port = 5000
+
+env.use_ssh_config = True
+
+home = "/home/site/pulse"
+log = "%s/hookshot.log" % home
+current = "%s/%s/current" % (home, environment)
+
+# principal command to run upon update
+command = "cd %s && git pull && bundle exec jekyll build >> %s" % (current, log)
+
+def start():
+  run(
+    "cd %s && forever start -l %s -a deploy/hookshot.js -p %i -b %s -c \"%s\""
+    % (current, log, port, branch, command)
+  )
+
+def stop():
+  run(
+    "cd %s && forever stop deploy/hookshot.js -p %i -b %s -c \"%s\""
+    % (current, port, branch, command)
+  )
+
+def restart():
+  run(
+    "cd %s && forever restart deploy/hookshot.js -p %i -b %s -c \"%s\""
+    % (current, port, branch, command)
+  )

--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -6,9 +6,9 @@ Manage auto-deploy webhooks remotely.
 
 Production hook:
 
-  forever start -l $HOME/pulse/hookshot.log -a deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
-  forever restart deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
-  forever stop deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull && bundle exec jekyll build >> $HOME/pulse/hookshot.log"
+  forever start -l $HOME/pulse/hookshot.log -a deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull >> $HOME/pulse/hookshot.log"
+  forever restart deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull >> $HOME/pulse/hookshot.log"
+  forever stop deploy/hookshot.js -p 5000 -b production -c "cd $HOME/pulse/production/current && git pull >> $HOME/pulse/hookshot.log"
 """
 
 environment = "production"
@@ -22,7 +22,7 @@ log = "%s/hookshot.log" % home
 current = "%s/%s/current" % (home, environment)
 
 # principal command to run upon update
-command = "cd %s && git pull && bundle exec jekyll build >> %s" % (current, log)
+command = "cd %s && git pull >> %s" % (current, log)
 
 def start():
   run(

--- a/deploy/pulse.conf
+++ b/deploy/pulse.conf
@@ -1,0 +1,43 @@
+server {
+  listen 443 ssl spdy;
+  server_name  pulse.cio.gov;
+
+  ssl_certificate      /etc/nginx/ssl/keys/pulse.cio.gov.chained.crt;
+  ssl_certificate_key  /etc/nginx/ssl/keys/pulse.cio.gov.key;
+  include ssl/ssl.rules;
+
+  error_page 404 /404/index.html;
+  error_page 500 /500/index.html;
+
+  location / {
+      root /home/site/pulse/production/current;
+      default_type text/html;
+  }
+
+  # production hook runs on port 5000
+  location /deploy {
+    proxy_pass http://localhost:5000/;
+    proxy_http_version 1.1;
+    proxy_redirect off;
+
+      proxy_set_header Host   $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_max_temp_file_size 0;
+
+      proxy_connect_timeout 10;
+      proxy_send_timeout    30;
+      proxy_read_timeout    30;
+  }
+
+  access_log  /home/site/pulse/log/nginx_access.log main;
+  error_log  /home/site/pulse/log/nginx_error.log;
+}
+
+# redirect for those clients not preloaded with pulse.cio.gov
+server {
+    listen 80;
+    server_name pulse.cio.gov;
+    return 301 https://pulse.cio.gov$request_uri;
+}

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 <![endif]-->
 
 <div class="container">
-    <h1>Hello world!</h1>
+    <h1>Hello world!!</h1>
 </div>
 
 <script src="js/main.js"></script>


### PR DESCRIPTION
This adds a tiny system for a webhook that hits our web server's nginx process, which is proxied to a local hookshot instance which runs a `git pull` on the directory where our static site is.

The `hookshot.js` file was added to `master` instead of `production` by mistake in https://github.com/18F/dotgov-dashboard/commit/4a14218cf57fc3e120dd144a26f1587e525e3960. 9_9 The rest is here.

It's not an ideal system, but it's the one used by 18f.gsa.gov and https.cio.gov, and very very similar to the one used by pages.18f.gov. I can imagine us moving to a CloudFoundry-based system like we're setting up for staging, after we evaluate the tradeoffs there.